### PR TITLE
refactor: group Vitest and coverage Dependabot updates together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,8 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 10
+  groups:
+    vitest-packages:
+      patterns:
+        - "vitest"
+        - "@vitest/coverage-v8"


### PR DESCRIPTION
This PR demonstrates grouping Dependabot packages together.

This PR is directly related to #12 which deliberately installed outdated versions of `Vitest` and `Vitest/coverage-v8`.
Manually triggering Dependabot cause 2 PRs to be created, one for each.

This PR is designed to always group `Vitest` and `Vitest/coverage-v8` updates together, as this is recommended for stability.